### PR TITLE
不要なヘッダーアイコンの削除

### DIFF
--- a/railsgym/layouts/default.vue
+++ b/railsgym/layouts/default.vue
@@ -5,22 +5,10 @@
       flat
       tile>
       <v-toolbar dense class="primary" :dark="true">
-        <v-app-bar-nav-icon />
         <v-toolbar-title>
           <router-link to="/" class="toolbar-title" v-text="title" />
         </v-toolbar-title>
         <v-spacer />
-        <v-btn icon>
-          <v-icon>mdi-magnify</v-icon>
-        </v-btn>
-
-        <v-btn icon>
-          <v-icon>mdi-heart</v-icon>
-        </v-btn>
-
-        <v-btn icon>
-          <v-icon>mdi-dots-vertical</v-icon>
-        </v-btn>
         <div v-if="loggedIn">
           <v-btn
             color="white"


### PR DESCRIPTION
ヘッダー部分の不要なアイコンを削除しました。

![railsgym-app_-_railsgym-app-3](https://user-images.githubusercontent.com/57358551/88473137-79bfbc80-cf55-11ea-8bed-fb91b2dda11e.png)

---

![railsgym-app_-_railsgym-app-4](https://user-images.githubusercontent.com/57358551/88473138-7cbaad00-cf55-11ea-8aa7-fb23fa9c731e.png)
