### PR TITLE
教材一覧ページの 技術名の右側に 投稿教材数 [xx件]を表示するように。

### DIFF
--- a/railsgym/pages/categories/_category/items/index.vue
+++ b/railsgym/pages/categories/_category/items/index.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <h2 class="page-title">
-      「{{ category.name }}」 教材一覧
+      「{{ category.name }}」 教材一覧 {{ category.items.length }} 件
     </h2>
     <div v-if="$auth.loggedIn" class="d-flex flex-row-reverse mb-6">
       <v-btn
@@ -43,7 +43,9 @@ import category from '~/apollo/queries/category'
 export default {
   data () {
     return {
-      category: {}
+      category: {
+        items: []
+      }
     }
   },
   async created () {

--- a/railsgym/pages/categories/_category/items/index.vue
+++ b/railsgym/pages/categories/_category/items/index.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <h2 class="page-title">
-      「{{ category.name }}」 教材一覧 {{ category.items.length }} 件
+      「{{ category.name }}」 教材一覧 {{ category.items.length }}件
     </h2>
     <div v-if="$auth.loggedIn" class="d-flex flex-row-reverse mb-6">
       <v-btn


### PR DESCRIPTION
## Issues
#23 

## 実装内容
- 教材一覧ページの技術名の右側に投稿教材数を表示

<img width="1438" alt="スクリーンショット 2020-08-01 16 49 53" src="https://user-images.githubusercontent.com/54099086/89097168-83df3080-d417-11ea-820d-7384f36f8f76.png">



